### PR TITLE
Replace text nodes only

### DIFF
--- a/content_script.js
+++ b/content_script.js
@@ -1,2 +1,10 @@
-var replaced = $("body").html().replace(/cyber/g,'<span class=\"rainbow\">wizard</span>').replace(/Cyber /g,'<span class=\"rainbow\">Wizard </span>').replace(/Cyber-/g,'<span class=\"rainbow\">Wizard-</span>');;
-$("body").html(replaced);
+$('body').find('*').contents().filter(function() { return (this.nodeType === 3) }).each(function(i, elm) {
+  if(this.textContent.match(/(cyber)|(Cyber\-)|(Cyber )/g)) {
+    this.textContent = this.textContent
+      .replace(/cyber/g, '<span class=\"rainbow\">wizard</span>')
+      .replace(/Cyber /g, '<span class=\"rainbow\">Wizard </span>')
+      .replace(/Cyber-/g, '<span class=\"rainbow\">Wizard-</span>');
+
+    this.parentNode.replaceChild($('<span>'+this.textContent+'</span>')[0], this)
+  }
+});


### PR DESCRIPTION
Altered this to replace text nodes only. This should keep the extension from breaking links.
